### PR TITLE
Fix some problems with CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: "3.6"
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: "Unit tests"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: "Unit tests"
-        run: py.test
+        run: PYTHONPATH=ctconvert pytest

--- a/ctconvert/tests/test_convert_data.py
+++ b/ctconvert/tests/test_convert_data.py
@@ -1,5 +1,5 @@
-"""Integration test for load_data.py script
-"""
+"""Integration test for load_data.py script"""
+
 import csv
 import os
 import json


### PR DESCRIPTION
* use Ubuntu-20.04
  * this is most recent github actions image that supports python3.6
  * see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
* fix #18 
* tests still fail for a fresh new reason